### PR TITLE
fix: phpstan fixed warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,25 @@ jobs:
           find . -name '*.php' -not -path './vendor/*' -not -path './tests/*' -print0 | \
             xargs -0 -n1 php -l
 
+  phpstan:
+    name: PHPStan Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: curl, mbstring, json
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --memory-limit=512M
+
   test:
     name: Tests (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
@@ -51,7 +70,7 @@ jobs:
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, test]
+    needs: [lint, phpstan, test]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Controllers/AiSummaryController.php
+++ b/Controllers/AiSummaryController.php
@@ -60,11 +60,11 @@ PROMPT;
 		}
 
 		// CSRF protection
-		if (Minz_Request::param('_csrf') !== FreshRSS_Auth::csrfToken()) {
+		if (Minz_Request::paramString('_csrf') !== FreshRSS_Auth::csrfToken()) {
 			Minz_Error::error(403);
 		}
 
-		$id = Minz_Request::param('id', '');
+		$id = Minz_Request::paramString('id');
 		if ($id === '') {
 			header('Content-Type: application/json; charset=UTF-8');
 			$this->sendJsonError('Missing entry ID', 400);
@@ -79,11 +79,22 @@ PROMPT;
 			return;
 		}
 
-		$provider = FreshRSS_Context::$user_conf->ai_summary_provider ?? 'openai';
-		$apiKey = FreshRSS_Context::$user_conf->ai_summary_api_key ?? '';
-		$model = FreshRSS_Context::$user_conf->ai_summary_model ?? '';
-		$apiUrl = FreshRSS_Context::$user_conf->ai_summary_api_url ?? '';
-		$customPrompt = FreshRSS_Context::$user_conf->ai_summary_prompt ?? '';
+		$user_conf = FreshRSS_Context::userConf();
+		/** @var mixed */
+		$provider = $user_conf->ai_summary_provider;
+		$provider = is_string($provider) ? $provider : 'openai';
+		/** @var mixed */
+		$apiKey = $user_conf->ai_summary_api_key;
+		$apiKey = is_string($apiKey) ? $apiKey : '';
+		/** @var mixed */
+		$model = $user_conf->ai_summary_model;
+		$model = is_string($model) ? $model : '';
+		/** @var mixed */
+		$apiUrl = $user_conf->ai_summary_api_url;
+		$apiUrl = is_string($apiUrl) ? $apiUrl : '';
+		/** @var mixed */
+		$customPrompt = $user_conf->ai_summary_prompt;
+		$customPrompt = is_string($customPrompt) ? $customPrompt : '';
 
 		if ($provider !== 'ollama' && $apiKey === '') {
 			header('Content-Type: application/json; charset=UTF-8');
@@ -100,7 +111,10 @@ PROMPT;
 		if (mb_strlen($content) < self::MIN_CONTENT_LENGTH) {
 			$link = $entry->link();
 			if ($link !== '') {
-				$this->sendEvent('status', json_encode(['message' => 'Fetching full article…']));
+				$statusMsg = json_encode(['message' => 'Fetching full article…']);
+				if (is_string($statusMsg)) {
+					$this->sendEvent('status', $statusMsg);
+				}
 				$fetched = $this->fetchArticleContent($link);
 				if ($fetched !== '') {
 					$content = $fetched;
@@ -111,9 +125,13 @@ PROMPT;
 		$content = mb_substr($content, 0, self::MAX_CONTENT_LENGTH);
 
 		$promptTemplate = $customPrompt !== '' ? $customPrompt : self::DEFAULT_PROMPT;
-		$langCode = FreshRSS_Context::$user_conf->ai_summary_language ?? '';
+		/** @var mixed */
+		$langCode = $user_conf->ai_summary_language;
+		$langCode = is_string($langCode) ? $langCode : '';
 		if ($langCode === '') {
-			$langCode = FreshRSS_Context::$user_conf->language ?? 'en';
+			/** @var mixed */
+			$langCode = $user_conf->language;
+			$langCode = is_string($langCode) ? $langCode : 'en';
 		}
 		$language = self::LANGUAGE_NAMES[$langCode] ?? $langCode;
 
@@ -131,16 +149,19 @@ PROMPT;
 			$userPrompt = 'Title: ' . $entry->title() . "\n\n" . $content;
 		}
 
-		$this->sendEvent('status', json_encode(['message' => 'Generating summary…']));
+		$statusMsg = json_encode(['message' => 'Generating summary…']);
+		if (is_string($statusMsg)) {
+			$this->sendEvent('status', $statusMsg);
+		}
 
 		try {
 			match ($provider) {
-				'openai' => $this->callOpenAI($apiKey, $model ?: self::DEFAULT_MODELS['openai'], $systemPrompt, $userPrompt),
-				'anthropic' => $this->callAnthropic($apiKey, $model ?: self::DEFAULT_MODELS['anthropic'], $systemPrompt, $userPrompt),
-				'gemini' => $this->callGemini($apiKey, $model ?: self::DEFAULT_MODELS['gemini'], $systemPrompt, $userPrompt),
+				'openai' => $this->callOpenAI($apiKey, $model !== '' ? $model : self::DEFAULT_MODELS['openai'], $systemPrompt, $userPrompt),
+				'anthropic' => $this->callAnthropic($apiKey, $model !== '' ? $model : self::DEFAULT_MODELS['anthropic'], $systemPrompt, $userPrompt),
+				'gemini' => $this->callGemini($apiKey, $model !== '' ? $model : self::DEFAULT_MODELS['gemini'], $systemPrompt, $userPrompt),
 				'ollama' => $this->callOllama(
 					$apiUrl !== '' ? $apiUrl : self::DEFAULT_OLLAMA_URL,
-					$model ?: self::DEFAULT_MODELS['ollama'],
+					$model !== '' ? $model : self::DEFAULT_MODELS['ollama'],
 					$systemPrompt,
 					$userPrompt,
 				),
@@ -148,7 +169,10 @@ PROMPT;
 			};
 			$this->sendEvent('done', '{}');
 		} catch (\Exception $e) {
-			$this->sendEvent('error', json_encode(['message' => $e->getMessage()]));
+			$errorMsg = json_encode(['message' => $e->getMessage()]);
+			if (is_string($errorMsg)) {
+				$this->sendEvent('error', $errorMsg);
+			}
 		}
 	}
 
@@ -194,9 +218,27 @@ PROMPT;
 					return;
 				}
 				$data = json_decode($json, true);
-				$text = $data['choices'][0]['delta']['content'] ?? '';
-				if ($text !== '') {
-					$this->sendEvent('chunk', json_encode(['text' => $text], JSON_UNESCAPED_UNICODE));
+				if (is_array($data)) {
+					/** @var mixed */
+					$choices = $data['choices'] ?? null;
+					if (is_array($choices) && isset($choices[0])) {
+						/** @var mixed */
+						$choice0 = $choices[0];
+						if (is_array($choice0)) {
+							/** @var mixed */
+							$delta = $choice0['delta'] ?? null;
+							if (is_array($delta)) {
+								$text = $delta['content'] ?? '';
+								$text = is_string($text) ? $text : '';
+								if ($text !== '') {
+									$chunk = json_encode(['text' => $text], JSON_UNESCAPED_UNICODE);
+									if (is_string($chunk)) {
+										$this->sendEvent('chunk', $chunk);
+									}
+								}
+							}
+						}
+					}
 				}
 			},
 		);
@@ -224,10 +266,18 @@ PROMPT;
 					return;
 				}
 				$data = json_decode(substr($line, 6), true);
-				if (($data['type'] ?? '') === 'content_block_delta') {
-					$text = $data['delta']['text'] ?? '';
-					if ($text !== '') {
-						$this->sendEvent('chunk', json_encode(['text' => $text], JSON_UNESCAPED_UNICODE));
+				if (is_array($data) && (($data['type'] ?? '') === 'content_block_delta')) {
+					/** @var mixed */
+					$delta = $data['delta'] ?? null;
+					if (is_array($delta)) {
+						$text = $delta['text'] ?? '';
+						$text = is_string($text) ? $text : '';
+						if ($text !== '') {
+							$chunk = json_encode(['text' => $text], JSON_UNESCAPED_UNICODE);
+							if (is_string($chunk)) {
+								$this->sendEvent('chunk', $chunk);
+							}
+						}
 					}
 				}
 			},
@@ -259,9 +309,35 @@ PROMPT;
 					return;
 				}
 				$data = json_decode(substr($line, 6), true);
-				$text = $data['candidates'][0]['content']['parts'][0]['text'] ?? '';
-				if ($text !== '') {
-					$this->sendEvent('chunk', json_encode(['text' => $text], JSON_UNESCAPED_UNICODE));
+				if (is_array($data)) {
+					/** @var mixed */
+					$candidates = $data['candidates'] ?? null;
+					if (is_array($candidates) && isset($candidates[0])) {
+						/** @var mixed */
+						$candidate0 = $candidates[0];
+						if (is_array($candidate0)) {
+							/** @var mixed */
+							$contentNode = $candidate0['content'] ?? null;
+							if (is_array($contentNode)) {
+								/** @var mixed */
+								$parts = $contentNode['parts'] ?? null;
+								if (is_array($parts) && isset($parts[0])) {
+									/** @var mixed */
+									$part0 = $parts[0];
+									if (is_array($part0)) {
+										$text = $part0['text'] ?? '';
+										$text = is_string($text) ? $text : '';
+										if ($text !== '') {
+											$chunk = json_encode(['text' => $text], JSON_UNESCAPED_UNICODE);
+											if (is_string($chunk)) {
+												$this->sendEvent('chunk', $chunk);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			},
 		);
@@ -286,12 +362,22 @@ PROMPT;
 					return;
 				}
 				if (isset($data['error'])) {
-					$msg = is_string($data['error']) ? $data['error'] : ($data['error']['message'] ?? 'Unknown error');
+					$errorObj = $data['error'];
+					$msg = is_string($errorObj) ? $errorObj : (is_array($errorObj) ? ($errorObj['message'] ?? 'Unknown error') : 'Unknown error');
+					$msg = is_string($msg) ? $msg : 'Unknown error';
 					throw new \RuntimeException('Ollama: ' . $msg);
 				}
-				$text = $data['message']['content'] ?? '';
-				if ($text !== '') {
-					$this->sendEvent('chunk', json_encode(['text' => $text], JSON_UNESCAPED_UNICODE));
+				/** @var mixed */
+				$messageNode = $data['message'] ?? null;
+				if (is_array($messageNode)) {
+					$text = $messageNode['content'] ?? '';
+					$text = is_string($text) ? $text : '';
+					if ($text !== '') {
+						$chunk = json_encode(['text' => $text], JSON_UNESCAPED_UNICODE);
+						if (is_string($chunk)) {
+							$this->sendEvent('chunk', $chunk);
+						}
+					}
 				}
 			},
 		);
@@ -377,7 +463,7 @@ PROMPT;
 			CURLOPT_RETURNTRANSFER => false,
 			CURLOPT_TIMEOUT => 120,
 			CURLOPT_CONNECTTIMEOUT => 10,
-			CURLOPT_WRITEFUNCTION => function ($ch, $data) use (&$buffer, &$rawResponse, $lineHandler, &$error) {
+			CURLOPT_WRITEFUNCTION => function ($ch, string $data) use (&$buffer, &$rawResponse, $lineHandler, &$error): int {
 				if (strlen($rawResponse) < 4096) {
 					$rawResponse .= $data;
 				}
@@ -419,8 +505,14 @@ PROMPT;
 		if ($httpCode >= 400) {
 			$errorData = json_decode($rawResponse, true);
 			if (is_array($errorData)) {
-				$msg = $errorData['error']['message'] ?? $errorData['error'] ?? 'HTTP ' . $httpCode;
-				throw new \RuntimeException('API error: ' . (is_string($msg) ? $msg : json_encode($msg)));
+				/** @var mixed */
+				$errorObj = $errorData['error'] ?? null;
+				if (is_array($errorObj)) {
+					$msg = $errorObj['message'] ?? $errorObj;
+				} else {
+					$msg = $errorObj ?? 'HTTP ' . $httpCode;
+				}
+				throw new \RuntimeException('API error: ' . (is_string($msg) ? $msg : (string) json_encode($msg)));
 			}
 			throw new \RuntimeException('API error: HTTP ' . $httpCode);
 		}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
 		"php": ">=8.1"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^11.0"
+		"phpunit/phpunit": "^11.0",
+		"phpstan/phpstan": "^2.1"
 	},
 	"autoload": {
 		"classmap": [

--- a/configure.phtml
+++ b/configure.phtml
@@ -1,5 +1,5 @@
 <?php
-/** @var FreshRSS_Extension $this */
+/** @var Minz_Extension $this */
 $provider = FreshRSS_Context::$user_conf->ai_summary_provider ?? '';
 $apiKey = FreshRSS_Context::$user_conf->ai_summary_api_key ?? '';
 $model = FreshRSS_Context::$user_conf->ai_summary_model ?? '';
@@ -24,7 +24,7 @@ $languages = [
 	'zh-cn' => 'Chinese (中文)',
 ];
 ?>
-<form action="<?= _url('extension', 'configure', 'e', urlencode($this->getName())) ?>" method="post">
+<form action="<?= _url('extension', 'configure', 'e', $this->getName()) ?>" method="post">
 	<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 
 	<div class="form-group">

--- a/extension.php
+++ b/extension.php
@@ -18,17 +18,17 @@ final class AiSummaryExtension extends Minz_Extension {
 		$this->registerTranslates();
 
 		if (Minz_Request::isPost()) {
-			if (Minz_Request::param('_csrf') !== FreshRSS_Auth::csrfToken()) {
+			if (Minz_Request::paramString('_csrf') !== FreshRSS_Auth::csrfToken()) {
 				Minz_Error::error(403);
 			}
-
-			FreshRSS_Context::$user_conf->ai_summary_provider = Minz_Request::param('ai_summary_provider', 'openai');
-			FreshRSS_Context::$user_conf->ai_summary_api_key = Minz_Request::param('ai_summary_api_key', '');
-			FreshRSS_Context::$user_conf->ai_summary_model = Minz_Request::param('ai_summary_model', '');
-			FreshRSS_Context::$user_conf->ai_summary_api_url = Minz_Request::param('ai_summary_api_url', '');
-			FreshRSS_Context::$user_conf->ai_summary_prompt = Minz_Request::param('ai_summary_prompt', '');
-			FreshRSS_Context::$user_conf->ai_summary_language = Minz_Request::param('ai_summary_language', '');
-			FreshRSS_Context::$user_conf->save();
+			$user_conf = FreshRSS_Context::userConf();
+			$user_conf->_attribute('ai_summary_provider', Minz_Request::paramString('ai_summary_provider') ?: 'openai');
+			$user_conf->_attribute('ai_summary_api_key', Minz_Request::paramString('ai_summary_api_key'));
+			$user_conf->_attribute('ai_summary_model', Minz_Request::paramString('ai_summary_model'));
+			$user_conf->_attribute('ai_summary_api_url', Minz_Request::paramString('ai_summary_api_url'));
+			$user_conf->_attribute('ai_summary_prompt', Minz_Request::paramString('ai_summary_prompt'));
+			$user_conf->_attribute('ai_summary_language', Minz_Request::paramString('ai_summary_language'));
+			$user_conf->save();
 		}
 	}
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 	"name": "AI Summary",
 	"author": "Pierre Mavro",
 	"description": "Summarize articles using AI providers (Gemini, Claude, ChatGPT, Ollama)",
-	"version": "1.0.0",
+	"version": "1.0.2",
 	"entrypoint": "AiSummary",
 	"type": "user"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+	level: 10
+	paths:
+		- Controllers/
+		- extension.php
+		- configure.phtml
+	excludePaths:
+		analyseAndScan:
+			- vendor/
+	scanFiles:
+		- tests/stubs/FreshRSS.php

--- a/tests/stubs/FreshRSS.php
+++ b/tests/stubs/FreshRSS.php
@@ -3,192 +3,172 @@
 declare(strict_types=1);
 
 /**
- * Minimal stubs for FreshRSS framework classes used by the extension.
- * These allow unit tests to run without the full FreshRSS installation.
+ * Enhanced stubs for FreshRSS framework classes.
  */
 
-// --- Minz_Extension ---
 class Minz_Extension {
+	public function install(): bool|string { return true; }
+	public function uninstall(): bool|string { return true; }
 	public function init(): void {}
-
 	public function handleConfigureAction(): void {}
 
-	public function getFileUrl(string $file, string $type): string {
-		return '/ext/' . $file;
+	public function getName(): string { return ''; }
+	public function getEntrypoint(): string { return ''; }
+	public function getPath(): string { return ''; }
+	public function getAuthor(): string { return ''; }
+	public function getDescription(): string { return ''; }
+	public function getVersion(): string { return ''; }
+	public function getType(): string { return 'user'; }
+
+	/** @return array<string, mixed> */
+	public function getSystemConfiguration(): array { return []; }
+	/** @param array<string, mixed> $config */
+	public function setSystemConfiguration(array $config): void {}
+	public function removeSystemConfiguration(): void {}
+
+	/** @return array<string, mixed> */
+	public function getUserConfiguration(): array { return []; }
+	/** @param array<string, mixed> $config */
+	public function setUserConfiguration(array $config): void {}
+	public function removeUserConfiguration(): void {}
+
+	public function getFileUrl(string $filename, string $type): string {
+		return '/ext/' . $filename;
 	}
 
-	public function getName(): string {
-		return 'AiSummary';
-	}
-
+	public function registerController(string $base_name): void {}
+	public function registerViews(): void {}
 	public function registerTranslates(): void {}
-
-	public function registerHook(string $name, callable $callback): void {}
-
-	public function registerController(string $name): void {}
+	public function registerHook(string $hook_name, callable $hook_function): void {}
 }
 
-// --- Minz_View ---
 class Minz_View {
-	private ?string $layout = '';
-
+	public Minz_ActionController $controller;
 	public static function appendStyle(string $url): void {}
-
 	public static function appendScript(string $url): void {}
-
-	public function _layout(?string $layout): void {
-		$this->layout = $layout;
-	}
+	public function _layout(?string $layout): void {}
 }
 
-// --- Minz_ActionController ---
 class Minz_ActionController {
 	public Minz_View $view;
-
 	public function __construct() {
 		$this->view = new Minz_View();
+		$this->view->controller = $this;
 	}
 }
 
-// --- Minz_Request ---
 class Minz_Request {
 	/** @var array<string, string> */
 	private static array $params = [];
-
-	public static function setParam(string $key, string $value): void {
-		self::$params[$key] = $value;
-	}
-
-	public static function param(string $key, string $default = ''): string {
-		return self::$params[$key] ?? $default;
-	}
-
-	public static function isPost(): bool {
-		return (self::$params['_method'] ?? '') === 'POST';
-	}
-
-	public static function reset(): void {
-		self::$params = [];
-	}
+	public static function setParam(string $key, string $value): void { self::$params[$key] = $value; }
+	/** @deprecated use paramString, paramInt, etc. */
+	public static function param(string $key, string $default = ''): string { return self::$params[$key] ?? $default; }
+	public static function paramString(string $name, bool $plaintext = true): string { return self::$params[$name] ?? ''; }
+	public static function paramStringNull(string $name, bool $plaintext = true): ?string { return self::$params[$name] ?? null; }
+	public static function paramInt(string $name, int $default = 0): int { return (int)(self::$params[$name] ?? $default); }
+	public static function paramBoolean(string $name): bool { return (bool)(self::$params[$name] ?? false); }
+	
+	public static function isPost(): bool { return (self::$params['_method'] ?? '') === 'POST'; }
+	public static function actionName(): string { return 'index'; }
+	public static function controllerName(): string { return 'index'; }
+	
+	public static function good(string $url, string $msg = ''): void {}
+	public static function bad(string $url, string $msg = ''): void {}
+	public static function reset(): void { self::$params = []; }
 }
 
-// --- FreshRSS_UserConfiguration (stub) ---
+/**
+ * @property string $ai_summary_provider
+ * @property string $ai_summary_api_key
+ * @property string $ai_summary_model
+ * @property string $ai_summary_api_url
+ * @property string $ai_summary_prompt
+ * @property string $ai_summary_language
+ * @property string $language
+ */
 class FreshRSS_UserConfiguration {
 	/** @var array<string, mixed> */
 	private array $data = [];
-
-	public function __get(string $name): mixed {
-		return $this->data[$name] ?? null;
-	}
-
-	public function __set(string $name, mixed $value): void {
-		$this->data[$name] = $value;
-	}
-
-	public function save(): bool {
-		return true;
-	}
+	public function __get(string $name): mixed { return $this->data[$name] ?? null; }
+	public function __set(string $name, mixed $value): void { $this->data[$name] = $value; }
+	public function save(): bool { return true; }
+	
+	public function attributeInt(string $name): int { return 0; }
+	public function attributeBool(string $name): bool { return false; }
+	public function _attribute(string $name, mixed $value): void { $this->data[$name] = $value; }
 }
 
-// --- FreshRSS_Context ---
 class FreshRSS_Context {
 	public static FreshRSS_UserConfiguration $user_conf;
-
+	public static function hasUserConf(): bool { return true; }
+	public static function hasSystemConf(): bool { return true; }
+	public static function userConf(): FreshRSS_UserConfiguration { return self::$user_conf; }
 	public static function init(): void {
 		self::$user_conf = new FreshRSS_UserConfiguration();
 	}
 }
 
-// --- FreshRSS_Auth ---
 class FreshRSS_Auth {
 	private static bool $hasAccess = true;
-
-	public static function setAccess(bool $access): void {
-		self::$hasAccess = $access;
-	}
-
-	public static function hasAccess(): bool {
-		return self::$hasAccess;
-	}
-
-	public static function csrfToken(): string {
-		return 'test-csrf-token';
-	}
+	public static function setAccess(bool $access): void { self::$hasAccess = $access; }
+	public static function hasAccess(): bool { return self::$hasAccess; }
+	public static function csrfToken(): string { return 'test-csrf-token'; }
 }
 
-// --- Minz_Error ---
 class Minz_Error {
 	public static function error(int $code): void {
 		throw new \RuntimeException('Minz Error ' . $code, $code);
 	}
 }
 
-// --- FreshRSS_Entry ---
 class FreshRSS_Entry {
 	private string $id;
 	private string $title;
 	private string $content;
 	private string $link;
-
 	public function __construct(string $id = '', string $title = '', string $content = '', string $link = '') {
 		$this->id = $id;
 		$this->title = $title;
 		$this->content = $content;
 		$this->link = $link;
 	}
-
-	public function id(): string {
-		return $this->id;
-	}
-
-	public function title(): string {
-		return $this->title;
-	}
-
-	public function content(): string {
-		return $this->content;
-	}
-
-	public function link(): string {
-		return $this->link;
-	}
-
-	public function _content(string $content): void {
-		$this->content = $content;
-	}
+	public function id(): string { return $this->id; }
+	public function title(): string { return $this->title; }
+	public function content(): string { return $this->content; }
+	public function link(): string { return $this->link; }
+	public function _content(string $content): void { $this->content = $content; }
 }
 
-// --- FreshRSS_EntryDAO ---
+class FreshRSS_Feed {
+	public function name(bool $takeAlias = false): string { return ''; }
+	public function favicon(): string { return ''; }
+	public function website(): string { return ''; }
+}
+
+class FreshRSS_FeedDAO {
+	public function searchById(int $id): ?FreshRSS_Feed { return null; }
+}
+
 class FreshRSS_EntryDAO {
 	/** @var array<string, FreshRSS_Entry> */
 	private static array $entries = [];
-
-	public static function addEntry(string $id, FreshRSS_Entry $entry): void {
-		self::$entries[$id] = $entry;
-	}
-
-	public static function clearEntries(): void {
-		self::$entries = [];
-	}
-
-	public function searchById(string $id): ?FreshRSS_Entry {
-		return self::$entries[$id] ?? null;
-	}
+	public static function addEntry(string $id, FreshRSS_Entry $entry): void { self::$entries[$id] = $entry; }
+	public static function clearEntries(): void { self::$entries = []; }
+	public function searchById(string $id): ?FreshRSS_Entry { return self::$entries[$id] ?? null; }
 }
 
-// --- FreshRSS_Factory ---
 class FreshRSS_Factory {
-	public static function createEntryDao(): FreshRSS_EntryDAO {
-		return new FreshRSS_EntryDAO();
-	}
+	public static function createEntryDao(): FreshRSS_EntryDAO { return new FreshRSS_EntryDAO(); }
+	public static function createFeedDao(): FreshRSS_FeedDAO { return new FreshRSS_FeedDAO(); }
 }
 
-// --- Translation function stub ---
-function _t(string $key, mixed ...$args): string {
-	return $key;
-}
+class Minz_Exception extends Exception {}
+class FreshRSS_Feed_Exception extends Exception {}
+class FreshRSS_Context_Exception extends Exception {}
 
-// --- URL helper stub ---
-function _url(string ...$args): string {
-	return '/?c=' . ($args[0] ?? '') . '&a=' . ($args[1] ?? '');
-}
+function _t(string $key, mixed ...$args): string { return $key; }
+function _i(string $icon): string { return ''; }
+/**
+ * @param string|int|array<string, mixed> $params
+ */
+function _url(string $c = '', string $a = '', string|int|array $params = [], mixed ...$args): string { return ''; }


### PR DESCRIPTION
## Summary by Sourcery

Improve type safety and PHPStan compatibility for the AiSummary extension and its FreshRSS test stubs.

Bug Fixes:
- Use typed Minz_Request helpers and safer handling of user configuration and JSON-encoded SSE payloads to avoid type-related runtime issues uncovered by PHPStan.

Enhancements:
- Expand and align FreshRSS framework stub classes with the real API surface to support stricter static analysis in tests.
- Harden streaming response handlers for OpenAI, Anthropic, Gemini, and Ollama by validating decoded JSON structures before use.
- Adjust AiSummary configuration handling to rely on FreshRSS_Context::userConf() and explicit attribute setters for better configuration management.

Build:
- Add a phpstan.neon configuration file to enable static analysis for the project.