### PR TITLE
feat: add perplexity support

### DIFF
--- a/Controllers/AiSummaryController.php
+++ b/Controllers/AiSummaryController.php
@@ -9,6 +9,7 @@ final class FreshExtension_AiSummary_Controller extends Minz_ActionController {
 		'anthropic' => 'claude-sonnet-4-6',
 		'gemini' => 'gemini-2.5-flash',
 		'ollama' => 'llama3.2',
+		'perplexity' => 'sonar',
 	];
 
 	private const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
@@ -176,6 +177,7 @@ PROMPT;
 					$systemPrompt,
 					$userPrompt,
 				),
+				'perplexity' => $this->callPerplexity($apiKey, $model !== '' ? $model : self::DEFAULT_MODELS['perplexity'], $systemPrompt, $userPrompt),
 				default => throw new \RuntimeException('Unknown provider: ' . $provider),
 			};
 			$this->sendEvent('done', '{}');
@@ -220,39 +222,55 @@ PROMPT;
 			'https://api.openai.com/v1/chat/completions',
 			['model' => $model, 'messages' => $messages, 'max_tokens' => 1024, 'stream' => true],
 			['Authorization: Bearer ' . $apiKey, 'Content-Type: application/json'],
-			function (string $line): void {
-				if (!str_starts_with($line, 'data: ')) {
-					return;
-				}
-				$json = substr($line, 6);
-				if (trim($json) === '[DONE]') {
-					return;
-				}
-				$data = json_decode($json, true);
-				if (is_array($data)) {
-					/** @var mixed */
-					$choices = $data['choices'] ?? null;
-					if (is_array($choices) && isset($choices[0])) {
-						/** @var mixed */
-						$choice0 = $choices[0];
-						if (is_array($choice0)) {
-							/** @var mixed */
-							$delta = $choice0['delta'] ?? null;
-							if (is_array($delta)) {
-								$text = $delta['content'] ?? '';
-								$text = is_string($text) ? $text : '';
-								if ($text !== '') {
-									$chunk = json_encode(['text' => $text], JSON_UNESCAPED_UNICODE);
-									if (is_string($chunk)) {
-										$this->sendEvent('chunk', $chunk);
-									}
-								}
-							}
-						}
-					}
-				}
-			},
+			fn (string $line) => $this->parseOpenAIStreamLine($line),
 		);
+	}
+
+	private function callPerplexity(string $apiKey, string $model, string $systemPrompt, string $userPrompt): void {
+		$messages = [];
+		if ($systemPrompt !== '') {
+			$messages[] = ['role' => 'system', 'content' => $systemPrompt];
+		}
+		$messages[] = ['role' => 'user', 'content' => $userPrompt];
+
+		$this->curlStreamRequest(
+			'https://api.perplexity.ai/chat/completions',
+			['model' => $model, 'messages' => $messages, 'max_tokens' => 1024, 'stream' => true],
+			['Authorization: Bearer ' . $apiKey, 'Content-Type: application/json'],
+			fn (string $line) => $this->parseOpenAIStreamLine($line),
+		);
+	}
+
+	private function parseOpenAIStreamLine(string $line): void {
+		if (!str_starts_with($line, 'data: ')) {
+			return;
+		}
+		$json = substr($line, 6);
+		if (trim($json) === '[DONE]') {
+			return;
+		}
+		$data = json_decode($json, true);
+		if (!is_array($data)) {
+			return;
+		}
+		/** @var mixed */
+		$choices = $data['choices'] ?? null;
+		if (!is_array($choices) || !isset($choices[0]) || !is_array($choices[0])) {
+			return;
+		}
+		/** @var mixed */
+		$delta = $choices[0]['delta'] ?? null;
+		if (!is_array($delta)) {
+			return;
+		}
+		$text = $delta['content'] ?? '';
+		if (!is_string($text) || $text === '') {
+			return;
+		}
+		$chunk = json_encode(['text' => $text], JSON_UNESCAPED_UNICODE);
+		if (is_string($chunk)) {
+			$this->sendEvent('chunk', $chunk);
+		}
 	}
 
 	private function callAnthropic(string $apiKey, string $model, string $systemPrompt, string $userPrompt): void {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **One-click summaries** — A "Summarize" button appears in every article. Click it to get an AI-generated summary streamed in real time below the title.
 - **Real-time streaming** — Summaries are delivered via Server-Sent Events (SSE), so you see text appear as the AI generates it, with a live typing cursor.
 - **Auto-fetch full articles** — When the RSS feed only contains a short excerpt, the extension automatically fetches and parses the full article from the original URL.
-- **4 AI providers** — Choose the one that fits your setup:
+- **5 AI providers** — Choose the one that fits your setup:
 
   | Provider | Default Model | API Key Required |
   |----------|--------------|:----------------:|
@@ -30,6 +30,7 @@
   | Anthropic (Claude) | `claude-sonnet-4-6` | Yes |
   | Google (Gemini) | `gemini-2.5-flash` | Yes |
   | Ollama | `llama3.2` | No |
+  | [Perplexity AI](https://docs.perplexity.ai/) | `sonar` | Yes |
 
 - **Custom prompts** — Override the default summarization prompt. Use `{content}`, `{title}`, and `{language}` placeholders in your template.
 - **Language override** — Choose the summary output language independently of your FreshRSS UI language.
@@ -68,7 +69,7 @@ git clone https://github.com/deimosfr/xExtension-AiSummary.git
 
 | Setting | Description |
 |---------|-------------|
-| **AI Provider** | Select OpenAI, Anthropic, Gemini, or Ollama. |
+| **AI Provider** | Select OpenAI, Anthropic, Gemini, Ollama, or Perplexity. |
 | **API Key** | Your provider's API key. Not required for Ollama. |
 | **Model** | Leave empty to use the provider's default (see table above), or specify any model your provider supports. |
 | **API URL** | Only for Ollama. Defaults to `http://localhost:11434`. |

--- a/configure.phtml
+++ b/configure.phtml
@@ -40,6 +40,7 @@ $languages = [
 				<option value="anthropic" <?= $provider === 'anthropic' ? 'selected' : '' ?>>Anthropic (Claude)</option>
 				<option value="gemini" <?= $provider === 'gemini' ? 'selected' : '' ?>>Google (Gemini)</option>
 				<option value="ollama" <?= $provider === 'ollama' ? 'selected' : '' ?>>Ollama</option>
+				<option value="perplexity" <?= $provider === 'perplexity' ? 'selected' : '' ?>>Perplexity AI</option>
 			</select>
 		</div>
 	</div>

--- a/i18n/cs/ext.php
+++ b/i18n/cs/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Není vyžadováno pro Ollama.',
 		'model' => 'Model',
 		'model_placeholder' => 'Ponechte prázdné pro výchozí',
-		'model_help' => 'Výchozí: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Výchozí: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'URL API',
 		'api_url_help' => 'Vyžadováno pouze pro Ollama. Výchozí: http://localhost:11434',
 		'prompt' => 'Vlastní prompt',

--- a/i18n/de/ext.php
+++ b/i18n/de/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Nicht erforderlich für Ollama.',
 		'model' => 'Modell',
 		'model_placeholder' => 'Leer lassen für Standard',
-		'model_help' => 'Standards: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Standards: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'API-URL',
 		'api_url_help' => 'Nur für Ollama erforderlich. Standard: http://localhost:11434',
 		'prompt' => 'Benutzerdefinierter Prompt',

--- a/i18n/en/ext.php
+++ b/i18n/en/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Not required for Ollama.',
 		'model' => 'Model',
 		'model_placeholder' => 'Leave empty for default',
-		'model_help' => 'Defaults: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Defaults: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'API URL',
 		'api_url_help' => 'Only required for Ollama. Default: http://localhost:11434',
 		'prompt' => 'Custom Prompt',

--- a/i18n/es/ext.php
+++ b/i18n/es/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'No requerida para Ollama.',
 		'model' => 'Modelo',
 		'model_placeholder' => 'Dejar vacío para el predeterminado',
-		'model_help' => 'Predeterminados: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Predeterminados: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'URL de la API',
 		'api_url_help' => 'Solo requerida para Ollama. Predeterminado: http://localhost:11434',
 		'prompt' => 'Prompt personalizado',

--- a/i18n/fr/ext.php
+++ b/i18n/fr/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Non requis pour Ollama.',
 		'model' => 'Modèle',
 		'model_placeholder' => 'Laisser vide pour le défaut',
-		'model_help' => 'Défauts : OpenAI : gpt-4o-mini, Claude : claude-sonnet-4-6, Gemini : gemini-2.5-flash, Ollama : llama3.2',
+		'model_help' => 'Défauts : OpenAI : gpt-4o-mini, Claude : claude-sonnet-4-6, Gemini : gemini-2.5-flash, Ollama : llama3.2, Perplexity : sonar',
 		'api_url' => 'URL de l\'API',
 		'api_url_help' => 'Requis uniquement pour Ollama. Défaut : http://localhost:11434',
 		'prompt' => 'Prompt personnalisé',

--- a/i18n/it/ext.php
+++ b/i18n/it/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Non richiesta per Ollama.',
 		'model' => 'Modello',
 		'model_placeholder' => 'Lasciare vuoto per il predefinito',
-		'model_help' => 'Predefiniti: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Predefiniti: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'URL API',
 		'api_url_help' => 'Richiesto solo per Ollama. Predefinito: http://localhost:11434',
 		'prompt' => 'Prompt personalizzato',

--- a/i18n/ja/ext.php
+++ b/i18n/ja/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Ollamaでは不要です。',
 		'model' => 'モデル',
 		'model_placeholder' => '空欄でデフォルトを使用',
-		'model_help' => 'デフォルト：OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'デフォルト：OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'API URL',
 		'api_url_help' => 'Ollamaのみ必要です。デフォルト：http://localhost:11434',
 		'prompt' => 'カスタムプロンプト',

--- a/i18n/ko/ext.php
+++ b/i18n/ko/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Ollama에는 필요하지 않습니다.',
 		'model' => '모델',
 		'model_placeholder' => '기본값을 사용하려면 비워두세요',
-		'model_help' => '기본값: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => '기본값: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'API URL',
 		'api_url_help' => 'Ollama에만 필요합니다. 기본값: http://localhost:11434',
 		'prompt' => '사용자 정의 프롬프트',

--- a/i18n/nl/ext.php
+++ b/i18n/nl/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Niet vereist voor Ollama.',
 		'model' => 'Model',
 		'model_placeholder' => 'Leeg laten voor standaard',
-		'model_help' => 'Standaard: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Standaard: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'API-URL',
 		'api_url_help' => 'Alleen vereist voor Ollama. Standaard: http://localhost:11434',
 		'prompt' => 'Aangepaste prompt',

--- a/i18n/pl/ext.php
+++ b/i18n/pl/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Nie wymagany dla Ollama.',
 		'model' => 'Model',
 		'model_placeholder' => 'Pozostaw puste dla domyślnego',
-		'model_help' => 'Domyślne: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Domyślne: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'Adres URL API',
 		'api_url_help' => 'Wymagany tylko dla Ollama. Domyślny: http://localhost:11434',
 		'prompt' => 'Niestandardowy prompt',

--- a/i18n/pt-br/ext.php
+++ b/i18n/pt-br/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Não necessária para Ollama.',
 		'model' => 'Modelo',
 		'model_placeholder' => 'Deixe vazio para o padrão',
-		'model_help' => 'Padrões: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Padrões: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'URL da API',
 		'api_url_help' => 'Necessária apenas para Ollama. Padrão: http://localhost:11434',
 		'prompt' => 'Prompt personalizado',

--- a/i18n/ru/ext.php
+++ b/i18n/ru/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Не требуется для Ollama.',
 		'model' => 'Модель',
 		'model_placeholder' => 'Оставьте пустым для значения по умолчанию',
-		'model_help' => 'По умолчанию: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'По умолчанию: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'URL API',
 		'api_url_help' => 'Требуется только для Ollama. По умолчанию: http://localhost:11434',
 		'prompt' => 'Пользовательский промпт',

--- a/i18n/tr/ext.php
+++ b/i18n/tr/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Ollama için gerekli değildir.',
 		'model' => 'Model',
 		'model_placeholder' => 'Varsayılan için boş bırakın',
-		'model_help' => 'Varsayılanlar: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => 'Varsayılanlar: OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'API URL',
 		'api_url_help' => 'Yalnızca Ollama için gereklidir. Varsayılan: http://localhost:11434',
 		'prompt' => 'Özel İstem',

--- a/i18n/zh-cn/ext.php
+++ b/i18n/zh-cn/ext.php
@@ -10,7 +10,7 @@ return [
 		'api_key_help' => 'Ollama 不需要。',
 		'model' => '模型',
 		'model_placeholder' => '留空使用默认值',
-		'model_help' => '默认值：OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2',
+		'model_help' => '默认值：OpenAI: gpt-4o-mini, Claude: claude-sonnet-4-6, Gemini: gemini-2.5-flash, Ollama: llama3.2, Perplexity: sonar',
 		'api_url' => 'API 地址',
 		'api_url_help' => '仅 Ollama 需要。默认：http://localhost:11434',
 		'prompt' => '自定义提示词',

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
 	"name": "AI Summary",
 	"author": "Pierre Mavro",
-	"description": "Summarize articles using AI providers (Gemini, Claude, ChatGPT, Ollama)",
-	"version": "1.1.0",
+	"description": "Summarize articles using AI providers (Gemini, Claude, ChatGPT, Ollama, Perplexity)",
+	"version": "1.2.0",
 	"entrypoint": "AiSummary",
 	"type": "user"
 }

--- a/tests/AiSummaryControllerTest.php
+++ b/tests/AiSummaryControllerTest.php
@@ -27,6 +27,7 @@ final class AiSummaryControllerTest extends TestCase {
 		self::assertArrayHasKey('anthropic', $models);
 		self::assertArrayHasKey('gemini', $models);
 		self::assertArrayHasKey('ollama', $models);
+		self::assertArrayHasKey('perplexity', $models);
 	}
 
 	public function testDefaultOllamaUrl(): void {

--- a/tests/I18nTest.php
+++ b/tests/I18nTest.php
@@ -113,6 +113,7 @@ final class I18nTest extends TestCase {
 		self::assertStringContainsString('claude-sonnet-4-6', $help, "Language '{$lang}' model_help missing Claude default");
 		self::assertStringContainsString('gemini-2.5-flash', $help, "Language '{$lang}' model_help missing Gemini default");
 		self::assertStringContainsString('llama3.2', $help, "Language '{$lang}' model_help missing Ollama default");
+		self::assertStringContainsString('sonar', $help, "Language '{$lang}' model_help missing Perplexity default");
 	}
 
 	public function testEnglishStringsMatchRequiredKeys(): void {


### PR DESCRIPTION
## Summary by Sourcery

Add Perplexity AI as a new summarization provider alongside existing AI services.

New Features:
- Introduce Perplexity AI as a selectable AI provider with default `sonar` model and streaming chat completion support.

Enhancements:
- Update UI configuration, README provider table, and localized `model_help` strings in all supported languages to mention the new Perplexity default model.

Tests:
- Extend controller and i18n tests to cover the Perplexity default model and provider presence.