### PR TITLE
feat: support OpenAI custom provider #6

### DIFF
--- a/Controllers/AiSummaryController.php
+++ b/Controllers/AiSummaryController.php
@@ -11,6 +11,8 @@ final class FreshExtension_AiSummary_Controller extends Minz_ActionController {
 		'ollama' => 'llama3.2',
 	];
 
+	private const DEFAULT_OPENAI_URL = 'https://api.openai.com/v1';
+
 	private const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
 
 	private const CONNECT_TIMEOUT = 10;
@@ -94,8 +96,11 @@ PROMPT;
 		$model = $user_conf->ai_summary_model;
 		$model = is_string($model) ? $model : '';
 		/** @var mixed */
-		$apiUrl = $user_conf->ai_summary_api_url;
-		$apiUrl = is_string($apiUrl) ? $apiUrl : '';
+		$openAiApiUrl = $user_conf->ai_summary_openai_api_url;
+		$openAiApiUrl = is_string($openAiApiUrl) ? $openAiApiUrl : '';
+		/** @var mixed */
+		$ollamaApiUrl = $user_conf->ai_summary_api_url;
+		$ollamaApiUrl = is_string($ollamaApiUrl) ? $ollamaApiUrl : '';
 		/** @var mixed */
 		$customPrompt = $user_conf->ai_summary_prompt;
 		$customPrompt = is_string($customPrompt) ? $customPrompt : '';
@@ -167,11 +172,17 @@ PROMPT;
 
 		try {
 			match ($provider) {
-				'openai' => $this->callOpenAI($apiKey, $model !== '' ? $model : self::DEFAULT_MODELS['openai'], $systemPrompt, $userPrompt),
+				'openai' => $this->callOpenAI(
+					$openAiApiUrl !== '' ? $openAiApiUrl : self::DEFAULT_OPENAI_URL,
+					$apiKey,
+					$model !== '' ? $model : self::DEFAULT_MODELS['openai'],
+					$systemPrompt,
+					$userPrompt,
+				),
 				'anthropic' => $this->callAnthropic($apiKey, $model !== '' ? $model : self::DEFAULT_MODELS['anthropic'], $systemPrompt, $userPrompt),
 				'gemini' => $this->callGemini($apiKey, $model !== '' ? $model : self::DEFAULT_MODELS['gemini'], $systemPrompt, $userPrompt),
 				'ollama' => $this->callOllama(
-					$apiUrl !== '' ? $apiUrl : self::DEFAULT_OLLAMA_URL,
+					$ollamaApiUrl !== '' ? $ollamaApiUrl : self::DEFAULT_OLLAMA_URL,
 					$model !== '' ? $model : self::DEFAULT_MODELS['ollama'],
 					$systemPrompt,
 					$userPrompt,
@@ -209,7 +220,19 @@ PROMPT;
 		echo "event: {$event}\ndata: {$data}\n\n";
 	}
 
-	private function callOpenAI(string $apiKey, string $model, string $systemPrompt, string $userPrompt): void {
+	private function buildOpenAiUrl(string $apiUrl): string {
+		$parts = parse_url($apiUrl);
+		if (!is_array($parts)
+			|| !isset($parts['host'], $parts['scheme'])
+			|| !in_array($parts['scheme'], ['http', 'https'], true)) {
+			throw new \RuntimeException('Invalid OpenAI-compatible API URL.');
+		}
+
+		$apiUrl = rtrim($apiUrl, '/');
+		return $apiUrl . (str_ends_with($apiUrl, '/v1') ? '' : '/v1') . '/chat/completions';
+	}
+
+	private function callOpenAI(string $apiUrl, string $apiKey, string $model, string $systemPrompt, string $userPrompt): void {
 		$messages = [];
 		if ($systemPrompt !== '') {
 			$messages[] = ['role' => 'system', 'content' => $systemPrompt];
@@ -217,7 +240,7 @@ PROMPT;
 		$messages[] = ['role' => 'user', 'content' => $userPrompt];
 
 		$this->curlStreamRequest(
-			'https://api.openai.com/v1/chat/completions',
+			$this->buildOpenAiUrl($apiUrl),
 			['model' => $model, 'messages' => $messages, 'max_tokens' => 1024, 'stream' => true],
 			['Authorization: Bearer ' . $apiKey, 'Content-Type: application/json'],
 			function (string $line): void {

--- a/configure.phtml
+++ b/configure.phtml
@@ -3,7 +3,8 @@
 $provider = FreshRSS_Context::$user_conf->ai_summary_provider ?? '';
 $apiKey = FreshRSS_Context::$user_conf->ai_summary_api_key ?? '';
 $model = FreshRSS_Context::$user_conf->ai_summary_model ?? '';
-$apiUrl = FreshRSS_Context::$user_conf->ai_summary_api_url ?? '';
+$openAiApiUrl = FreshRSS_Context::$user_conf->ai_summary_openai_api_url ?? '';
+$ollamaApiUrl = FreshRSS_Context::$user_conf->ai_summary_api_url ?? '';
 $prompt = FreshRSS_Context::$user_conf->ai_summary_prompt ?? '';
 $language = FreshRSS_Context::$user_conf->ai_summary_language ?? '';
 $timeout = FreshRSS_Context::$user_conf->ai_summary_timeout ?? AiSummaryExtension::TIMEOUT_DEFAULT;
@@ -65,10 +66,19 @@ $languages = [
 	</div>
 
 	<div class="form-group">
-		<label class="group-name" for="ai_summary_api_url"><?= _t('ext.ai_summary.api_url') ?></label>
+		<label class="group-name" for="ai_summary_openai_api_url"><?= _t('ext.ai_summary.api_url') ?> (OpenAI-compatible)</label>
+		<div class="group-controls">
+			<input type="url" name="ai_summary_openai_api_url" id="ai_summary_openai_api_url"
+				value="<?= htmlspecialchars($openAiApiUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"
+				placeholder="https://api.openai.com/v1" />
+		</div>
+	</div>
+
+	<div class="form-group">
+		<label class="group-name" for="ai_summary_api_url"><?= _t('ext.ai_summary.api_url') ?> (Ollama)</label>
 		<div class="group-controls">
 			<input type="url" name="ai_summary_api_url" id="ai_summary_api_url"
-				value="<?= htmlspecialchars($apiUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"
+				value="<?= htmlspecialchars($ollamaApiUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"
 				placeholder="http://localhost:11434" />
 			<p class="help"><?= _t('ext.ai_summary.api_url_help') ?></p>
 		</div>

--- a/extension.php
+++ b/extension.php
@@ -29,6 +29,7 @@ final class AiSummaryExtension extends Minz_Extension {
 			$user_conf->_attribute('ai_summary_provider', Minz_Request::paramString('ai_summary_provider') ?: 'openai');
 			$user_conf->_attribute('ai_summary_api_key', Minz_Request::paramString('ai_summary_api_key'));
 			$user_conf->_attribute('ai_summary_model', Minz_Request::paramString('ai_summary_model'));
+			$user_conf->_attribute('ai_summary_openai_api_url', Minz_Request::paramString('ai_summary_openai_api_url'));
 			$user_conf->_attribute('ai_summary_api_url', Minz_Request::paramString('ai_summary_api_url'));
 			$user_conf->_attribute('ai_summary_prompt', Minz_Request::paramString('ai_summary_prompt'));
 			$user_conf->_attribute('ai_summary_language', Minz_Request::paramString('ai_summary_language'));

--- a/tests/AiSummaryControllerTest.php
+++ b/tests/AiSummaryControllerTest.php
@@ -34,6 +34,11 @@ final class AiSummaryControllerTest extends TestCase {
 		self::assertSame('http://localhost:11434', $ref->getValue());
 	}
 
+	public function testDefaultOpenAiUrl(): void {
+		$ref = new \ReflectionClassConstant(FreshExtension_AiSummary_Controller::class, 'DEFAULT_OPENAI_URL');
+		self::assertSame('https://api.openai.com/v1', $ref->getValue());
+	}
+
 	public function testMaxContentLengthIsPositive(): void {
 		$ref = new \ReflectionClassConstant(FreshExtension_AiSummary_Controller::class, 'MAX_CONTENT_LENGTH');
 		self::assertGreaterThan(0, $ref->getValue());
@@ -132,9 +137,30 @@ final class AiSummaryControllerTest extends TestCase {
 
 	public function testCallOpenAIMethodSignature(): void {
 		$ref = new \ReflectionMethod(FreshExtension_AiSummary_Controller::class, 'callOpenAI');
-		self::assertSame(4, $ref->getNumberOfParameters());
+		self::assertSame(5, $ref->getNumberOfParameters());
 		$params = array_map(fn ($p) => $p->getName(), $ref->getParameters());
-		self::assertSame(['apiKey', 'model', 'systemPrompt', 'userPrompt'], $params);
+		self::assertSame(['apiUrl', 'apiKey', 'model', 'systemPrompt', 'userPrompt'], $params);
+	}
+
+	public function testBuildOpenAiUrlAcceptsVersionedAndBareBases(): void {
+		$ref = new \ReflectionMethod(FreshExtension_AiSummary_Controller::class, 'buildOpenAiUrl');
+
+		self::assertSame(
+			'https://gateway.example/v1/chat/completions',
+			$ref->invoke($this->controller, 'https://gateway.example/v1'),
+		);
+		self::assertSame(
+			'https://gateway.example/v1/chat/completions',
+			$ref->invoke($this->controller, 'https://gateway.example/'),
+		);
+	}
+
+	public function testBuildOpenAiUrlRejectsUnsupportedSchemes(): void {
+		$ref = new \ReflectionMethod(FreshExtension_AiSummary_Controller::class, 'buildOpenAiUrl');
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('Invalid OpenAI-compatible API URL.');
+		$ref->invoke($this->controller, 'file:///etc/passwd');
 	}
 
 	public function testCallAnthropicMethodSignature(): void {

--- a/tests/AiSummaryExtensionTest.php
+++ b/tests/AiSummaryExtensionTest.php
@@ -84,6 +84,7 @@ final class AiSummaryExtensionTest extends TestCase {
 		Minz_Request::setParam('ai_summary_provider', 'anthropic');
 		Minz_Request::setParam('ai_summary_api_key', 'sk-ant-test');
 		Minz_Request::setParam('ai_summary_model', 'claude-sonnet-4-6');
+		Minz_Request::setParam('ai_summary_openai_api_url', 'https://gateway.example/v1');
 		Minz_Request::setParam('ai_summary_api_url', '');
 		Minz_Request::setParam('ai_summary_prompt', 'Custom prompt here');
 		Minz_Request::setParam('ai_summary_timeout', '45');
@@ -93,6 +94,7 @@ final class AiSummaryExtensionTest extends TestCase {
 		self::assertSame('anthropic', FreshRSS_Context::$user_conf->ai_summary_provider);
 		self::assertSame('sk-ant-test', FreshRSS_Context::$user_conf->ai_summary_api_key);
 		self::assertSame('claude-sonnet-4-6', FreshRSS_Context::$user_conf->ai_summary_model);
+		self::assertSame('https://gateway.example/v1', FreshRSS_Context::$user_conf->ai_summary_openai_api_url);
 		self::assertSame('Custom prompt here', FreshRSS_Context::$user_conf->ai_summary_prompt);
 		self::assertSame(45, FreshRSS_Context::$user_conf->ai_summary_timeout);
 	}

--- a/tests/stubs/FreshRSS.php
+++ b/tests/stubs/FreshRSS.php
@@ -81,6 +81,7 @@ class Minz_Request {
  * @property string $ai_summary_provider
  * @property string $ai_summary_api_key
  * @property string $ai_summary_model
+ * @property string $ai_summary_openai_api_url
  * @property string $ai_summary_api_url
  * @property string $ai_summary_prompt
  * @property string $ai_summary_language


### PR DESCRIPTION
## Summary by Sourcery

Add support for configurable OpenAI-compatible API URLs while preserving existing Ollama configuration, and adjust OpenAI request handling accordingly.

New Features:
- Allow specifying a custom base URL for OpenAI-compatible providers, separate from the Ollama API URL.

Enhancements:
- Derive the OpenAI chat completions endpoint from a validated base URL, defaulting to the official OpenAI API URL when none is provided.
- Update configuration UI and persistence to handle distinct OpenAI and Ollama API URLs.

Tests:
- Extend controller and extension tests to cover the new OpenAI URL configuration, URL builder behavior, and updated method signatures.