### PR TITLE
fix: keep summary content below compact control

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,22 +1,34 @@
 'use strict';
 
 (function () {
-	var aiIcon = '<svg class="ai-summary-icon" viewBox="0 0 512 512" width="16" height="16" fill="currentColor">'
-		+ '<path d="M208 0c13 0 22 9 25 21l26 105 105 26c12 3 21 12 21 25s-9 22-21 25l-105 26-26 105c-3 12-12 21-25 21s-22-9-25-21l-26-105L52 202c-12-3-21-12-21-25s9-22 21-25l105-26L183 21c3-12 12-21 25-21z"/>'
-		+ '<path d="M384 288c8 0 14 5 16 13l14 55 55 14c8 2 13 8 13 16s-5 14-13 16l-55 14-14 55c-2 8-8 13-16 13s-14-5-16-13l-14-55-55-14c-8-2-13-8-13-16s5-14 13-16l55-14 14-55c2-8 8-13 16-13z" opacity="0.7"/>'
-		+ '</svg>';
+	var nextSummaryId = 0;
 
 	function initButtons() {
 		var wrappers = document.querySelectorAll('.ai-summary-wrapper:not(.ai-summary-initialized)');
 		wrappers.forEach(function (wrapper) {
 			var label = wrapper.dataset.label || 'Summarize';
-			wrapper.innerHTML = '<button type="button" class="ai-summary-btn" aria-expanded="false" title="' + escapeHtml(label) + '">' + aiIcon + ' <span class="ai-summary-label"></span></button>'
-				+ '<div class="ai-summary-content"></div>';
-			// Security fix: use textContent for label
-			var labelSpan = wrapper.querySelector('.ai-summary-label');
-			if (labelSpan) {
-				labelSpan.textContent = label;
-			}
+			var button = document.createElement('button');
+			button.type = 'button';
+			button.className = 'ai-summary-btn';
+			button.setAttribute('aria-expanded', 'false');
+			button.title = label;
+
+			var icon = document.createElement('span');
+			icon.className = 'ai-summary-icon';
+			icon.setAttribute('aria-hidden', 'true');
+			icon.textContent = '✦';
+			button.appendChild(icon);
+
+			var labelSpan = document.createElement('span');
+			labelSpan.className = 'ai-summary-label';
+			labelSpan.textContent = label;
+			button.appendChild(labelSpan);
+
+			var contentDiv = document.createElement('div');
+			contentDiv.className = 'ai-summary-content';
+			contentDiv.id = 'ai-summary-content-' + (++nextSummaryId);
+			button.setAttribute('aria-controls', contentDiv.id);
+			wrapper.replaceChildren(button, contentDiv);
 			wrapper.classList.add('ai-summary-initialized');
 		});
 	}

--- a/static/script.js
+++ b/static/script.js
@@ -27,6 +27,10 @@
 			var contentDiv = document.createElement('div');
 			contentDiv.className = 'ai-summary-content';
 			contentDiv.id = 'ai-summary-content-' + (++nextSummaryId);
+			contentDiv.setAttribute('role', 'region');
+			contentDiv.setAttribute('aria-live', 'polite');
+			contentDiv.setAttribute('aria-busy', 'false');
+			contentDiv.setAttribute('aria-label', label + ' summary');
 			button.setAttribute('aria-controls', contentDiv.id);
 			wrapper.replaceChildren(button, contentDiv);
 			wrapper.classList.add('ai-summary-initialized');
@@ -74,6 +78,24 @@
 		var entryId = wrapper.dataset.entryId;
 		var contentDiv = wrapper.querySelector('.ai-summary-content');
 
+		function syncExpandedState() {
+			btn.setAttribute(
+				'aria-expanded',
+				contentDiv.classList.contains('ai-summary-visible') ? 'true' : 'false',
+			);
+		}
+
+		function showError(message) {
+			var error = document.createElement('p');
+			error.className = 'ai-summary-error';
+			error.textContent = '⚠ ' + message;
+			contentDiv.replaceChildren(error);
+			contentDiv.classList.add('ai-summary-visible');
+			contentDiv.dataset.loaded = '';
+			contentDiv.setAttribute('aria-busy', 'false');
+			syncExpandedState();
+		}
+
 		// Toggle: if summary is visible, hide it
 		if (contentDiv.classList.contains('ai-summary-visible') && contentDiv.dataset.loaded) {
 			contentDiv.classList.remove('ai-summary-visible');
@@ -113,7 +135,8 @@
 			el = el.parentElement;
 		}
 		contentDiv.classList.add('ai-summary-visible');
-		btn.setAttribute('aria-expanded', 'true');
+		contentDiv.setAttribute('aria-busy', 'true');
+		syncExpandedState();
 		contentDiv.innerHTML = '<p class="ai-summary-placeholder">Initializing…</p>';
 
 		var formData = new URLSearchParams();
@@ -131,7 +154,7 @@
 			if (contentType.indexOf('application/json') !== -1) {
 				return response.json().then(function (data) {
 					if (data.error) {
-						contentDiv.innerHTML = '<p class="ai-summary-error">⚠ ' + escapeHtml(data.error) + '</p>';
+						showError(data.error);
 					}
 				});
 			}
@@ -164,12 +187,14 @@
 						fullText += data.text;
 						summaryDiv.innerHTML = formatSummary(fullText);
 					} else if (currentEvent === 'error') {
-						contentDiv.innerHTML = '<p class="ai-summary-error">⚠ ' + escapeHtml(data.message) + '</p>';
+						showError(data.message);
 					} else if (currentEvent === 'done') {
 						if (summaryDiv) {
 							summaryDiv.classList.remove('ai-summary-streaming');
 						}
 						contentDiv.dataset.loaded = '1';
+						contentDiv.setAttribute('aria-busy', 'false');
+						syncExpandedState();
 					}
 					currentEvent = '';
 				}
@@ -186,6 +211,8 @@
 								summaryDiv.classList.remove('ai-summary-streaming');
 							}
 							contentDiv.dataset.loaded = '1';
+							contentDiv.setAttribute('aria-busy', 'false');
+							syncExpandedState();
 						}
 						return;
 					}
@@ -204,11 +231,13 @@
 
 			return read();
 		}).catch(function (err) {
-			contentDiv.innerHTML = '<p class="ai-summary-error">⚠ ' + escapeHtml(err.message) + '</p>';
+			showError(err.message);
 		}).finally(function () {
 			btn.disabled = false;
 			btn.classList.remove('ai-summary-loading');
 			btn.innerHTML = originalHTML;
+			contentDiv.setAttribute('aria-busy', 'false');
+			syncExpandedState();
 		});
 	});
 

--- a/static/script.js
+++ b/static/script.js
@@ -10,7 +10,7 @@
 		var wrappers = document.querySelectorAll('.ai-summary-wrapper:not(.ai-summary-initialized)');
 		wrappers.forEach(function (wrapper) {
 			var label = wrapper.dataset.label || 'Summarize';
-			wrapper.innerHTML = '<button type="button" class="ai-summary-btn btn btn-important">' + aiIcon + ' <span class="ai-summary-label"></span></button>'
+			wrapper.innerHTML = '<button type="button" class="ai-summary-btn" aria-expanded="false" title="' + escapeHtml(label) + '">' + aiIcon + ' <span class="ai-summary-label"></span></button>'
 				+ '<div class="ai-summary-content"></div>';
 			// Security fix: use textContent for label
 			var labelSpan = wrapper.querySelector('.ai-summary-label');
@@ -65,12 +65,14 @@
 		// Toggle: if summary is visible, hide it
 		if (contentDiv.classList.contains('ai-summary-visible') && contentDiv.dataset.loaded) {
 			contentDiv.classList.remove('ai-summary-visible');
+			btn.setAttribute('aria-expanded', 'false');
 			return;
 		}
 
 		// If already loaded, just show it
 		if (contentDiv.dataset.loaded) {
 			contentDiv.classList.add('ai-summary-visible');
+			btn.setAttribute('aria-expanded', 'true');
 			return;
 		}
 
@@ -99,6 +101,7 @@
 			el = el.parentElement;
 		}
 		contentDiv.classList.add('ai-summary-visible');
+		btn.setAttribute('aria-expanded', 'true');
 		contentDiv.innerHTML = '<p class="ai-summary-placeholder">Initializing…</p>';
 
 		var formData = new URLSearchParams();

--- a/static/style.css
+++ b/static/style.css
@@ -1,12 +1,12 @@
 .ai-summary-wrapper {
-	text-align: center;
-	display: block;
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+	margin: 0.65em 0 0.85em;
 }
 
 .ai-summary-wrapper.ai-summary-initialized {
-	margin-bottom: 1.5em;
-	padding-bottom: 1.5em;
-	border-bottom: 1px solid var(--frss-border-color, #eee);
+	margin-bottom: 0.85em;
 }
 
 /* Hide ONLY in collapsed list items in Normal view */
@@ -15,8 +15,31 @@
 }
 
 .ai-summary-btn {
+	appearance: none;
+	border: 1px solid rgba(128, 128, 128, 0.22);
+	border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+	border-radius: 999px;
+	background: rgba(128, 128, 128, 0.08);
+	background: color-mix(in srgb, currentColor 7%, transparent);
+	color: inherit;
 	cursor: pointer;
-	font-size: 0.9em;
+	font-size: 0.84em;
+	font-weight: 600;
+	line-height: 1.2;
+	padding: 0.42em 0.8em;
+	transition: background-color 120ms ease, border-color 120ms ease, transform 120ms ease;
+}
+
+.ai-summary-btn:hover:not(:disabled),
+.ai-summary-btn:focus-visible {
+	border-color: color-mix(in srgb, currentColor 42%, transparent);
+	background: color-mix(in srgb, currentColor 14%, transparent);
+	transform: translateY(-1px);
+}
+
+.ai-summary-btn:focus-visible {
+	outline: 2px solid color-mix(in srgb, currentColor 60%, transparent);
+	outline-offset: 2px;
 }
 
 .ai-summary-btn.ai-summary-loading {
@@ -30,13 +53,14 @@
 	margin-top: 0.8em;
 	padding: 0.8em 1em;
 	color: inherit;
-	border: 2px solid transparent;
+	border: 1px solid rgba(128, 128, 128, 0.38);
+	border: 1px solid color-mix(in srgb, var(--ai-summary-accent, currentColor) 38%, transparent);
 	border-radius: 6px;
-	background:
-		linear-gradient(var(--ai-summary-bg, #f5f5f5), var(--ai-summary-bg, #f5f5f5)) padding-box,
-		linear-gradient(to top right, #3b82f6, #8b5cf6) border-box;
+	background: rgba(128, 128, 128, 0.06);
+	background: color-mix(in srgb, var(--ai-summary-accent, currentColor) 6%, transparent);
 	font-size: 0.92em;
 	line-height: 1.5;
+	box-shadow: none;
 }
 
 .ai-summary-content.ai-summary-visible {

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,6 @@
 .ai-summary-wrapper {
-	display: flex;
-	justify-content: flex-start;
-	align-items: center;
+	display: block;
+	text-align: left;
 	margin: 0.65em 0 0.85em;
 }
 


### PR DESCRIPTION
Fixes the layout regression in #9 by keeping the summary wrapper in normal block flow. The compact theme-aware button remains left-aligned, while the expanded summary renders below it at full width.

Verification:
- `node --check static/script.js`
- CSS layout assertions for block flow and below-button expansion

## Summary by Sourcery

Restore the summary layout while improving control accessibility and theme-aware styling.

Bug Fixes:
- Keep the expanded summary below the compact control in normal block flow, preventing the layout regression.

Enhancements:
- Refresh the summary control styling for compact, theme-aware presentation.
- Improve summary controls with accessible expanded, loading, error, and region states.

Tests:
- Add verification for JavaScript syntax and summary block-flow layout behavior.